### PR TITLE
# [Фронтенд] Отчёты: список пользователей и Excel-выгрузка

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -7,7 +7,7 @@ const connectDB = require("./config/db")
 const authRoutes = require("./routes/authRoutes")
 const userRoutes = require("./routes/userRoutes")
 const taskRoutes = require("./routes/taskRoutes")
-const reportRoutes = require("./routes/taskRoutes")
+const reportRoutes = require("./routes/reportRoutes")
 
 const app = express();
 

--- a/frontend/Pro-Control/src/components/avatar-group.jsx
+++ b/frontend/Pro-Control/src/components/avatar-group.jsx
@@ -1,20 +1,31 @@
-import React from 'react';
+import React from "react";
+import { LuUser } from "react-icons/lu";
 
-export const AvatarGroup = ({ avatars, maxVisible = 3 }) => {
+export const AvatarGroup = ({ avatars, names = [], maxVisible = 3 }) => {
     return (
         <div className="flex items-center">
-            {avatars
-                .filter((avatar) => avatar) // убираем null, undefined, ""
-                .slice(0, maxVisible)
-                .map((avatar, index) => (
-                    <img
-                        key={index}
-                        src={avatar}
-                        alt={`Avatar ${index}`}
-                        className="w-9 h-9 rounded-full border-2 border-white -ml-3 first:ml-0"
-                    />
-                ))}
-            {avatars.filter((avatar) => avatar).length > maxVisible && (
+            {avatars.slice(0, maxVisible).map((avatar, index) => (
+                <div key={index} className="relative group -ml-3 first:ml-0">
+                    {avatar ? (
+                        <img
+                            src={avatar}
+                            alt={`Avatar ${index}`}
+                            className="w-9 h-9 rounded-full border-2 border-white"
+                        />
+                    ) : (
+                        <div className="w-9 h-9 rounded-full border-2 border-white bg-gray-200 flex items-center justify-center text-gray-600">
+                            <LuUser className="w-5 h-5" />
+                        </div>
+                    )}
+
+                    {/* кастомный tooltip */}
+                    <div className="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 whitespace-nowrap bg-black text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
+                        {names[index]}
+                    </div>
+                </div>
+            ))}
+
+            {avatars.length > maxVisible && (
                 <div className="w-9 h-9 flex items-center justify-center bg-blue-50 text-sm font-medium rounded-full border-2 border-white -ml-3">
                     +{avatars.length - maxVisible}
                 </div>

--- a/frontend/Pro-Control/src/components/avatar-group.jsx
+++ b/frontend/Pro-Control/src/components/avatar-group.jsx
@@ -1,32 +1,44 @@
 import React from "react";
-import { LuUser } from "react-icons/lu";
+import {LuUser} from "react-icons/lu";
 
-export const AvatarGroup = ({ avatars, names = [], maxVisible = 3 }) => {
+export const AvatarGroup = ({avatars, names = [], maxVisible = 3}) => {
     return (
         <div className="flex items-center">
-            {avatars.slice(0, maxVisible).map((avatar, index) => (
-                <div key={index} className="relative group -ml-3 first:ml-0">
-                    {avatar ? (
-                        <img
-                            src={avatar}
-                            alt={`Avatar ${index}`}
-                            className="w-9 h-9 rounded-full border-2 border-white"
-                        />
-                    ) : (
-                        <div className="w-9 h-9 rounded-full border-2 border-white bg-gray-200 flex items-center justify-center text-gray-600">
-                            <LuUser className="w-5 h-5" />
-                        </div>
-                    )}
+            {avatars.slice(0, maxVisible).map((avatar, index) => {
+                const name = names[index] || ""; // добавляем имя по индексу
 
-                    {/* кастомный tooltip */}
-                    <div className="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 whitespace-nowrap bg-black text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
-                        {names[index]}
+                return (
+                    <div key={index} className="relative group -ml-3 first:ml-0">
+                        {avatar ? (
+                            <img
+                                src={avatar}
+                                alt={`Avatar ${index}`}
+                                className="w-9 h-9 rounded-full border-2 border-white"
+                            />
+                        ) : (
+                            <div
+                                className="w-9 h-9 rounded-full border-2 border-white bg-gray-200 flex items-center justify-center text-gray-600">
+                                <LuUser className="w-5 h-5"/>
+                            </div>
+                        )}
+
+                        {/* кастомный tooltip */}
+                        {name && (
+                            <div className="absolute left-1/2 -translate-x-1/2 top-full mt-2
+                            bg-black text-white text-xs rounded px-2 py-1
+                            opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10"
+                            >
+                                {name}
+                            </div>
+                        )}
                     </div>
-                </div>
-            ))}
+                );
+            })}
+
 
             {avatars.length > maxVisible && (
-                <div className="w-9 h-9 flex items-center justify-center bg-blue-50 text-sm font-medium rounded-full border-2 border-white -ml-3">
+                <div
+                    className="w-9 h-9 flex items-center justify-center bg-blue-50 text-sm font-medium rounded-full border-2 border-white -ml-3">
                     +{avatars.length - maxVisible}
                 </div>
             )}

--- a/frontend/Pro-Control/src/components/avatar-group.jsx
+++ b/frontend/Pro-Control/src/components/avatar-group.jsx
@@ -5,7 +5,7 @@ export const AvatarGroup = ({avatars, names = [], maxVisible = 3}) => {
     return (
         <div className="flex items-center">
             {avatars.slice(0, maxVisible).map((avatar, index) => {
-                const name = names[index] || ""; // добавляем имя по индексу
+                const name = names[index] || "";
 
                 return (
                     <div key={index} className="relative group -ml-3 first:ml-0">

--- a/frontend/Pro-Control/src/components/cards/user-card.jsx
+++ b/frontend/Pro-Control/src/components/cards/user-card.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { LuUser } from "react-icons/lu";
+
+export const UserCard = ({ userInfo }) => {
+  const {
+    name,
+    email,
+    profileImageUrl,
+    pendingTasks,
+    inProgressTasks,
+    completedTasks,
+  } = userInfo;
+
+  return (
+      <div className="p-4 border rounded-lg bg-white shadow-sm flex flex-col gap-4">
+        <div className="flex items-center gap-4">
+          {profileImageUrl ? (
+              <img
+                  src={profileImageUrl}
+                  alt={name}
+                  className="w-12 h-12 rounded-full object-cover border-2 border-white"
+              />
+          ) : (
+              <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center">
+                <LuUser className="text-gray-400 text-xl" />
+              </div>
+          )}
+
+          <div className="flex flex-col">
+            <p className="text-sm font-medium text-gray-800">{name}</p>
+            <p className="text-xs text-gray-500">{email}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between text-center text-[11px] font-medium">
+          <StatCard label="Ожидают" count={pendingTasks || 0} status="Pending" />
+          <StatCard label="В работе" count={inProgressTasks || 0} status="In Progress" />
+          <StatCard label="Завершены" count={completedTasks || 0} status="Completed" />
+        </div>
+      </div>
+  );
+};
+
+const StatCard = ({ label, count, status }) => {
+  const getStatusTagColor = () => {
+    switch (status) {
+      case "In Progress":
+        return "text-cyan-600 bg-cyan-50";
+      case "Completed":
+        return "text-indigo-600 bg-indigo-50";
+      default:
+        return "text-violet-600 bg-violet-50";
+    }
+  };
+
+  return (
+      <div className={`flex-1 px-3 py-1 rounded ${getStatusTagColor()}`}>
+        <div className="text-[13px] font-semibold">{count}</div>
+        <div>{label}</div>
+      </div>
+  );
+};

--- a/frontend/Pro-Control/src/components/charts/custom-bar-chart.jsx
+++ b/frontend/Pro-Control/src/components/charts/custom-bar-chart.jsx
@@ -36,7 +36,7 @@ export const CustomBarChart = ({data}) => {
                         {payload[0].payload.priority}
                     </p>
                     <p className="text-sm text-gray-600">
-                        Count:{" "}
+                        Задач:{" "}
                         <span className="text-sm font-medium text-gray-900">
               {payload[0].payload.count}
             </span>

--- a/frontend/Pro-Control/src/components/charts/custom-tooltip.jsx
+++ b/frontend/Pro-Control/src/components/charts/custom-tooltip.jsx
@@ -6,7 +6,7 @@ export const CustomTooltip = ({active, payload}) => {
             <div className="bg-white shadow-md rounded-lg p-2 border border-gray-300">
                 <p className="text-xs font-semibold text-purple-800 mb-1">{payload[0].name}</p>
                 <p className="text-sm text-gray-600">
-                    Count: <span className="text-sm font-medium text-gray-900">{payload[0].value}</span>
+                    Задач: <span className="text-sm font-medium text-gray-900">{payload[0].value}</span>
                 </p>
             </div>
         );

--- a/frontend/Pro-Control/src/components/inputs/select-users.jsx
+++ b/frontend/Pro-Control/src/components/inputs/select-users.jsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {API_PATHS} from "../../utils/api-paths";
 import axiosInstance from "../../utils/axios-instance";
-import {LuUsers} from "react-icons/lu";
+import {LuUser} from "react-icons/lu";
 import {Modal} from "../modal";
 import {AvatarGroup} from "../avatar-group";
 
@@ -61,7 +61,7 @@ export const SelectUsers = ({selectedUsers, setSelectedUsers}) => {
         <div className="space-y-4 mt-2">
             {selectedUserAvatars.length === 0 && (
                 <button className="card-btn" onClick={() => setIsModalOpen(true)}>
-                    <LuUsers className="text-sm"/> Добавить участников
+                    <LuUser className="text-sm"/> Добавить участников
                 </button>
             )}
 
@@ -83,11 +83,17 @@ export const SelectUsers = ({selectedUsers, setSelectedUsers}) => {
                             key={user._id}
                             className="flex items-center gap-4 p-3 border-b border-gray-200"
                         >
-                            <img
-                                src={user.profileImageUrl || null}
-                                alt={user.name}
-                                className="w-10 h-10 rounded-full"
-                            />
+                            {user.profileImageUrl ? (
+                                <img
+                                    src={user.profileImageUrl}
+                                    alt={user.name}
+                                    className="w-10 h-10 rounded-full border-2 border-white"
+                                />
+                            ) : (
+                                <div className="w-10 h-10 rounded-full border-2 border-white bg-gray-200 flex items-center justify-center text-gray-600">
+                                    <LuUser className="w-5 h-5" />
+                                </div>
+                            )}
                             <div className="flex-1">
                                 <p className="font-medium text-gray-800 dark:text-white">
                                     {user.name}

--- a/frontend/Pro-Control/src/components/inputs/select-users.jsx
+++ b/frontend/Pro-Control/src/components/inputs/select-users.jsx
@@ -39,7 +39,11 @@ export const SelectUsers = ({selectedUsers, setSelectedUsers}) => {
 
     const selectedUserAvatars = allUsers
         .filter((user) => selectedUsers.includes(user._id))
-        .map((user) => user.profileImageUrl);
+        .map((user) => user.profileImageUrl || null);
+
+    const selectedUserNames = allUsers
+        .filter((user) => selectedUsers.includes(user._id))
+        .map((user) => user.name);
 
     useEffect(() => {
         getAllUsers();
@@ -63,7 +67,8 @@ export const SelectUsers = ({selectedUsers, setSelectedUsers}) => {
 
             {selectedUserAvatars.length > 0 && (
                 <div className="cursor-pointer" onClick={() => setIsModalOpen(true)}>
-                    <AvatarGroup avatars={selectedUserAvatars} maxVisible={3}/>
+                    <AvatarGroup avatars={selectedUserAvatars} names={selectedUserNames} maxVisible={3} />
+
                 </div>
             )}
 

--- a/frontend/Pro-Control/src/components/inputs/select-users.jsx
+++ b/frontend/Pro-Control/src/components/inputs/select-users.jsx
@@ -50,12 +50,11 @@ export const SelectUsers = ({selectedUsers, setSelectedUsers}) => {
     }, []);
 
     useEffect(() => {
-        if (selectedUsers.length === 0) {
-            setTempSelectedUsers([]);
+        if (isModalOpen) {
+            setTempSelectedUsers(selectedUsers); // копируем выбранных
         }
+    }, [isModalOpen]);
 
-        return () => {};
-    }, [selectedUsers]);
 
     return (
         <div className="space-y-4 mt-2">

--- a/frontend/Pro-Control/src/index.css
+++ b/frontend/Pro-Control/src/index.css
@@ -12,6 +12,7 @@
         font-family: var(--font-display), sans-serif;
     }
     body {
+        /*background-color: #fcfbfc;*/
         background-color: #fcfbfc;
         overflow-x: hidden;
     }

--- a/frontend/Pro-Control/src/index.css
+++ b/frontend/Pro-Control/src/index.css
@@ -49,3 +49,6 @@
 .add-btn {
     @apply w-full flex items-center justify-center gap-1.5 text-xs md:text-sm font-medium text-primary whitespace-nowrap bg-blue-50 border border-blue-100 rounded-lg px-4 py-2 cursor-pointer;
 }
+.download-btn {
+    @apply items-center gap-3 text-xs md:text-[13px] text-lime-900 bg-lime-100 px-2 md:px-3 py-2 rounded border border-lime-200 hover:border-lime-400 cursor-pointer;
+}

--- a/frontend/Pro-Control/src/pages/admin/manage-tasks.jsx
+++ b/frontend/Pro-Control/src/pages/admin/manage-tasks.jsx
@@ -6,6 +6,7 @@ import { API_PATHS } from "../../utils/api-paths.js";
 import { LuFileSpreadsheet } from "react-icons/lu";
 import { TaskStatusTabs } from "../../components/task-status-tabs.jsx";
 import { TaskCard } from "../../components/Cards/task-card.jsx";
+import {toast} from "react-toastify";
 
 // Маппинг для фильтрации и отображения
 const statusMap = {
@@ -49,7 +50,26 @@ export const ManageTasks = () => {
     const handleClick = (taskData) => {
         navigate(`/admin/create-task`, { state: { taskId: taskData._id } });
     };
+    const handleDownloadReport = async () => {
+        try {
+            const response = await axiosInstance.get(API_PATHS.REPORTS.EXPORT_TASKS, {
+                responseType: "blob",
+            });
 
+            // Create a URL for the blob
+            const url = window.URL.createObjectURL(new Blob([response.data]));
+            const link = document.createElement("a");
+            link.href = url;
+            link.setAttribute("download", "task_details.xlsx");
+            document.body.appendChild(link);
+            link.click();
+            link.parentNode.removeChild(link);
+            window.URL.revokeObjectURL(url);
+        } catch (error) {
+            console.error("Error downloading details:", error);
+            toast.error("Failed to download details. Please try again.");
+        }
+    };
     useEffect(() => {
         getAllTasks(filterStatus);
     }, [filterStatus]);
@@ -63,6 +83,7 @@ export const ManageTasks = () => {
 
                         <button
                             className="flex lg:hidden download-btn"
+                            onClick={handleDownloadReport}
                         >
                             <LuFileSpreadsheet className="text-lg" />
                             Скачать отчет
@@ -79,6 +100,7 @@ export const ManageTasks = () => {
 
                             <button
                                 className="hidden lg:flex download-btn"
+                                onClick={handleDownloadReport}
                             >
                                 <LuFileSpreadsheet className="text-lg" />
                                 Скачать отчет

--- a/frontend/Pro-Control/src/pages/admin/manage-users.jsx
+++ b/frontend/Pro-Control/src/pages/admin/manage-users.jsx
@@ -1,9 +1,71 @@
-import React from 'react';
+import React, { useEffect, useState } from "react";
+import { DashboardLayout } from "../../components/layouts/dashboard-layout.jsx";
+import { API_PATHS } from "../../utils/api-paths.js";
+import axiosInstance from "../../utils/axios-instance.js";
+import { LuFileSpreadsheet } from "react-icons/lu";
+import { UserCard } from "../../components/cards/user-card.jsx";
+import { toast } from "react-toastify";
 
 export const ManageUsers = () => {
+    const [allUsers, setAllUsers] = useState([]);
+
+    const getAllUsers = async () => {
+        try {
+            const response = await axiosInstance.get(API_PATHS.USERS.GET_ALL_USERS);
+            if (response.data?.length > 0) {
+                setAllUsers(response.data);
+            }
+        } catch (error) {
+            console.error("Ошибка при получении пользователей:", error);
+        }
+    };
+
+    // Загрузка отчета о пользователях
+    const handleDownloadReport = async () => {
+        try {
+            const response = await axiosInstance.get(API_PATHS.REPORTS.EXPORT_USERS, {
+                responseType: "blob",
+            });
+
+            const url = window.URL.createObjectURL(new Blob([response.data]));
+            const link = document.createElement("a");
+            link.href = url;
+            link.setAttribute("download", "список_пользователей.xlsx");
+            document.body.appendChild(link);
+            link.click();
+            link.parentNode.removeChild(link);
+            window.URL.revokeObjectURL(url);
+        } catch (error) {
+            console.error("Ошибка при скачивании отчета:", error);
+            toast.error("Не удалось скачать отчет. Пожалуйста, попробуйте снова.");
+        }
+    };
+
+    useEffect(() => {
+        getAllUsers();
+    }, []);
+
     return (
-        <div>
-            ManageUsers
-        </div>
+        <DashboardLayout activeMenu="Team Members">
+            <div className="mt-5 mb-10">
+                <div className="flex md:flex-row md:items-center justify-between">
+                    <h2 className="text-xl md:text-xl font-medium">Участники команды</h2>
+
+                    <button
+                        className="flex md:flex download-btn"
+                        onClick={handleDownloadReport}
+                    >
+                        <LuFileSpreadsheet className="text-lg" />
+                        Скачать отчёт
+                    </button>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+                    {allUsers?.map((user) => (
+                        <UserCard key={user._id} userInfo={user} />
+                    ))}
+                </div>
+            </div>
+        </DashboardLayout>
     );
 };


### PR DESCRIPTION
## Что реализовано

- Добавлен компонент `UserCard` и реализовано отображение списка пользователей с их статистикой
- Реализована возможность скачивания двух Excel-отчётов:
  - общий отчёт по всем пользователям
  - детализированный отчёт по задачам
- Настроена локализация заголовков и значений (статус, приоритет) в выгружаемых Excel-файлах
- Добавлен отдельный CSS-класс `download-btn` для единообразной стилизации зелёных кнопок скачивания
- Исправлена ошибка импорта путей (`reportRoutes` вместо `taskRoutes`)
- Синхронизация выбранных пользователей при открытии модального окна (во избежание сброса)
- Реализован fallback — если у пользователя отсутствует `profileImageUrl`, подставляется иконка-заглушка
- Имя пользователя отображается в tooltip при наведении на аватар в `AvatarGroup`
- Добавлен кастомный tooltip к `AvatarGroup` с корректным переводом (например: `3 Задачи`, а не `Count - Задач`)

## Цель

Целью данной задачи было реализовать полноценный модуль работы с отчетами: от отображения пользователей до скачивания Excel-файлов со статистикой. Особое внимание уделено:
- локализации данных в выгружаемых файлах;
- UX-удобству при работе с модальными окнами и аватарами;
- единообразию в стилизации кнопок и отображении информации.

## Ветка

`feature/frontend/reports`

## Коммиты

```bash
feat: add UserCard component and integrate user listing with stats and report download
feat: localized headers and status/priority values in task and user Excel reports
feat: added download-btn class for consistent green button styling
fix: correct import of reportRoutes instead of taskRoutes
fix: sync selected users on modal open to prevent accidental clearing
fix: fallback to user icon if profileImageUrl is missing in modal
fix: show user names in tooltip under avatar in AvatarGroup
feat: add custom tooltip to AvatarGroup instead of default title fix: translate Count - Задач